### PR TITLE
windows support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 # Public (interface) dependencies.
 target_link_libraries(${PROJECT_NAME} PUBLIC
 	sdptransform
-	${LIBWEBRTC_BINARY_PATH}/libwebrtc${CMAKE_STATIC_LIBRARY_SUFFIX}
+	${LIBWEBRTC_BINARY_PATH}/${CMAKE_STATIC_LIBRARY_PREFIX}webrtc${CMAKE_STATIC_LIBRARY_SUFFIX}
 )
 
 # Compile definitions for libwebrtc.

--- a/src/PeerConnection.cpp
+++ b/src/PeerConnection.cpp
@@ -100,7 +100,7 @@ namespace mediasoupclient
 		MSC_TRACE();
 
 		auto config = options.config;
-		this->factory = options.factory ?: PeerConnection::DefaultFactory();
+		this->factory = options.factory ? options.factory : PeerConnection::DefaultFactory();
 
 		// Set SDP semantics to Unified Plan.
 		config.sdp_semantics = webrtc::SdpSemantics::kUnifiedPlan;


### PR DESCRIPTION
- remove elvis operator (MSVC doesn't support it)
- link to webrtc.lib on windows instead of libwebrtc.a