### PR TITLE
Fix CMake compatibility with Homebrew's CMake 4.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(mediasoupclient LANGUAGES CXX)
 

--- a/deps/libsdptransform/CMakeLists.txt
+++ b/deps/libsdptransform/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 project(sdptransform VERSION 1.2.9)
 


### PR DESCRIPTION
When installing CMake via Homebrew on macOS, it installs CMake 4.x which has removed support for CMake minimum versions < 3.5. This causes build failures in libmediasoupclient.

This change ensures compatibility with modern CMake installations while maintaining support for older systems.

Alternatively, I think we just should consider updating libmediasoupclient . Is there any reason why we shouldn't do that?
We are using a version that's 3 years old (3.4.0) and there have been some improvements since then.

```
### 3.4.3

* Update to libwebrtc M120/6099 ([#173](https://github.com/versatica/libmediasoupclient/pull/173)). Thanks @Poldraunic, @janreyho, @copiltembel.

### 3.4.2

* Fix explicit codec selection ([#164](https://github.com/versatica/libmediasoupclient/pull/164)). Thanks @fedulvtubudul.


### 3.4.1

* Clear the stored transceivers before closing the PeerConnection ([#156](https://github.com/versatica/libmediasoupclient/pull/156)). Thanks @adriancretu.
* Fix non-virtual destructors ([PR #157](https://github.com/versatica/libmediasoupclient/pull/157)). Thanks @adriancretu.
* Fix min max range inclusion. ([PR #158](https://github.com/versatica/libmediasoupclient/pull/158)). Thanks @adriancretu.
* Update libsdptransform to 1.2.10 ([PR #171](https://github.com/versatica/libmediasoupclient/pull/171)). Thanks@copiltembel.
```

Finally, I'm not sure about the release process of this type of change, let me know if it's done differently!